### PR TITLE
Revert "fix: We cannot require() an env var on node 23, so just use the $CONFIG blob."

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ NodeJs scripts (with no dependencies) used to manage ReliefWeb Trello Boards.
 Configuration
 -------------
 
-The scripts need some configuration. This can should be passed using the `CONFIG` environment variable.
+The scripts need some configuration. This is defined in a JSON file, whose path should be passed using the `CONFIG` environment variable.
 
-Ex: `CONFIG=$(cat config/countries.config.json) node src/countries.js`
+Ex: `CONFIG=../config/countries.config.json node src/countries.js`
 
 The `config` directory contains examples that just need to the Trello API crendentials and board ID.
 
@@ -22,7 +22,7 @@ Docker
 
 1. Clone the repository somewhere and `cd` to it.
 2. Edit the config file.
-3. Run the script with something like `docker run --rm -v "$(pwd)/src:/tmp" -e CONFIG="$(cat config/countries.config.json)" node:latest node /tmp/countries.js`
+3. Run the script with something like `docker run --rm -v "$(pwd)/src:/tmp" -v "$(pwd)/config/countries.config.json:/tmp/countries.config.json" -e CONFIG=/tmp/countries.config.json node:latest node /tmp/countries.js`
 
 Development
 -----------

--- a/src/countries.js
+++ b/src/countries.js
@@ -403,7 +403,7 @@ function CountryManager(config, logger, trelloClient, rwapiClient, date) {
 /**
  * Execute logic.
  */
-const config = process.env.CONFIG;
+const config = require(process.env.CONFIG);
 
 const Logger = require('./libs/logger.js').Logger;
 const logger = new Logger(config.debug);

--- a/src/disasters.js
+++ b/src/disasters.js
@@ -713,7 +713,7 @@ function DisasterManager(config, logger, trelloClient, rwapiClient, date) {
 /**
  * Execute logic.
  */
-const config = process.env.CONFIG;
+const config = require(process.env.CONFIG);
 
 const Logger = require('./libs/logger.js').Logger;
 const logger = new Logger(config.debug);

--- a/src/overview.js
+++ b/src/overview.js
@@ -400,7 +400,7 @@ function OverviewManager(config, logger, trelloClient, date) {
 /**
  * Execute logic.
  */
-const config = process.env.CONFIG;
+const config = require(process.env.CONFIG);
 
 const Logger = require('./libs/logger.js').Logger;
 const logger = new Logger(config.debug);

--- a/src/topics.js
+++ b/src/topics.js
@@ -782,7 +782,7 @@ function TopicManager(config, logger, trelloClient, rwapiClient, date) {
 /**
  * Execute logic.
  */
-const config = process.env.CONFIG;
+const config = require(process.env.CONFIG);
 
 const Logger = require('./libs/logger.js').Logger;
 const logger = new Logger(config.debug);


### PR DESCRIPTION
The README was wrong. Will update this PR to amend it. The commands run fine as they are with node 22.
